### PR TITLE
Minor fix a description mismatch in 0108_lab_hellor.Rmd

### DIFF
--- a/0108_lab_hellor.Rmd
+++ b/0108_lab_hellor.Rmd
@@ -119,7 +119,7 @@ knitr::include_graphics("img/g2.png")
 knitr::include_graphics("img/g3.png")
 ```
 
-In this case, the template is DataScience4Psych/lab-01-plastic-waste
+In this case, the template is DataScience4Psych/lab-02-plastic-waste
 
 ```{r eval=TRUE, fig.margin = TRUE, echo = FALSE, fig.width=3}
 knitr::include_graphics("img/g4.png")


### PR DESCRIPTION
Noticed a small inconsistency in the tutorial:
the text refers to DataScience4Psych/lab-01-plastic-waste, while the screenshots and actual workflow use lab-02-plastic-waste.