### PR TITLE
Update 0905_bias_lab.Rmd

### DIFF
--- a/0905_bias_lab.Rmd
+++ b/0905_bias_lab.Rmd
@@ -228,7 +228,7 @@ Note that their are many ways to measure bias in an algorithm. In this exercise,
 
 13. In 2016, ProPublica and Northpointe (the company that created COMPAS) had a disagreement about how to measure fairness. ProPublica focused on error rates (false positives and false negatives), while Northpointe focused on calibration (whether the same score means the same probability of recidivism across groups).
 
-    Based on your analysis, do you see evidence supporting Northpointe's claim that the algorithm is biased? Explain your reasoning.
+    Based on your calibration analysis, do you see evidence supporting Northpointe's claim that the algorithm is fair? Explain your reasoning.
 
 ```{r bias_lab-code-check-calibration, }
 # To check calibration, you can calculate recidivism rates by score for each race


### PR DESCRIPTION
change the description of exe13  
exercise13. In 2016, ProPublica and Northpointe (the company that created COMPAS).......I think the above exercise talks about the  ProPublica plan, so maybe this exercise is for Northpointe? because here we calculate calibration index

